### PR TITLE
Finalize Hamiltonian cycle refactor and stabilize tests

### DIFF
--- a/src/engine/gameEngine.js
+++ b/src/engine/gameEngine.js
@@ -19,30 +19,19 @@ import { DEFAULT_CONFIG } from '../utils/constants.js';
 export function initializeGame(config = DEFAULT_CONFIG) {
   const { rows, cols, seed, ...otherConfig } = { ...DEFAULT_CONFIG, ...config };
 
-  console.log('Initializing game with config:', { rows, cols, seed });
-
   // Generate Hamiltonian cycle
   const hamiltonianData = generateHamiltonianCycle(rows, cols);
-  
+
   if (!hamiltonianData.cycle || hamiltonianData.cycle.length === 0) {
     throw new Error('Failed to generate Hamiltonian cycle');
   }
-
-  console.log('Hamiltonian cycle generated:', {
-    length: hamiltonianData.cycle.length,
-    expected: rows * cols
-  });
 
   // Initialize snake at first position in cycle
   const startCell = hamiltonianData.cycle[0];
   const snake = createSnake(startCell);
 
-  console.log('Snake initialized at cell:', startCell);
-
   // Spawn initial fruit
   const fruit = spawnFruit(snake.occupied, hamiltonianData.cycle.length);
-
-  console.log('Fruit spawned at cell:', fruit);
 
   const initialState = {
     config: { rows, cols, seed, ...otherConfig },
@@ -59,13 +48,6 @@ export function initializeGame(config = DEFAULT_CONFIG) {
       shortcutEdge: null,
     },
   };
-
-  console.log('Initial game state created:', {
-    snakeLength: initialState.snake.body.length,
-    fruitPosition: initialState.fruit,
-    cycleLength: initialState.cycle.length,
-    status: initialState.status
-  });
 
   return initialState;
 }
@@ -98,7 +80,6 @@ export function gameTick(gameState) {
   // Check collision
   const collision = checkCollision(nextCell, gameState);
   if (collision.collision) {
-    console.warn('Collision detected:', collision);
     return {
       state: { ...gameState, status: GAME_STATUS.GAME_OVER },
       result: { valid: false, reason: collision.reason, collision: collision.type },
@@ -137,8 +118,8 @@ export function gameTick(gameState) {
       fruit: newFruit,
       score:
         gameState.score +
-        (config.scorePerfruit || 10) +
-        (pathPlan.isShortcut ? (config.shortcutBonus || 5) : 0),
+        (config.scorePerFruit ?? DEFAULT_CONFIG.scorePerFruit) +
+        (pathPlan.isShortcut ? (config.shortcutBonus ?? DEFAULT_CONFIG.shortcutBonus) : 0),
     };
 
     // Check if game complete after eating
@@ -178,7 +159,6 @@ function calculatePlannedPath(snake, fruit, cycle, cycleIndex) {
   const fruitPos = cycleIndex.get(fruit);
 
   if (headPos === undefined || fruitPos === undefined) {
-    console.warn('Could not find head or fruit position in cycle');
     return [];
   }
 

--- a/src/tests/engine/hamiltonian.test.js
+++ b/src/tests/engine/hamiltonian.test.js
@@ -9,11 +9,23 @@ import { generateHamiltonianCycle, validateCycle } from '../../engine/hamiltonia
 describe('Hamiltonian Cycle', () => {
   describe('generateHamiltonianCycle', () => {
     it('should generate valid cycle for small grid', () => {
-      const hamiltonian = generateHamiltonianCycle(3, 3);
+      const rows = 3;
+      const cols = 4;
+      const hamiltonian = generateHamiltonianCycle(rows, cols);
 
-      expect(hamiltonian.cycle).toHaveLength(9);
-      expect(hamiltonian.cycleIndex.size).toBe(9);
-      expect(validateCycle(hamiltonian.cycle, 9)).toBe(true);
+      expect(hamiltonian.cycle).toHaveLength(rows * cols);
+      expect(hamiltonian.cycleIndex.size).toBe(rows * cols);
+      expect(validateCycle(hamiltonian.cycle, rows, cols)).toBe(true);
+    });
+
+    it('should generate valid cycle when only columns are even', () => {
+      const rows = 5;
+      const cols = 6; // even number of columns, odd rows
+      const hamiltonian = generateHamiltonianCycle(rows, cols);
+
+      expect(hamiltonian.cycle).toHaveLength(rows * cols);
+      expect(hamiltonian.cycleIndex.size).toBe(rows * cols);
+      expect(validateCycle(hamiltonian.cycle, rows, cols)).toBe(true);
     });
 
     it('should generate valid cycle for standard grid', () => {
@@ -21,7 +33,7 @@ describe('Hamiltonian Cycle', () => {
 
       expect(hamiltonian.cycle).toHaveLength(400);
       expect(hamiltonian.cycleIndex.size).toBe(400);
-      expect(validateCycle(hamiltonian.cycle, 400)).toBe(true);
+      expect(validateCycle(hamiltonian.cycle, 20, 20)).toBe(true);
     });
 
     it('should have correct next/prev relationships', () => {
@@ -49,15 +61,15 @@ describe('Hamiltonian Cycle', () => {
 
   describe('validateCycle', () => {
     it('should accept valid cycles', () => {
-      expect(validateCycle([0, 1, 2, 3], 4)).toBe(true);
-      expect(validateCycle([3, 0, 2, 1], 4)).toBe(true);
+      expect(validateCycle([0, 1, 3, 2], 2, 2)).toBe(true);
+      expect(validateCycle([0, 2, 3, 1], 2, 2)).toBe(true);
     });
 
     it('should reject invalid cycles', () => {
-      expect(validateCycle([0, 1, 2], 4)).toBe(false); // Wrong length
-      expect(validateCycle([0, 1, 1, 3], 4)).toBe(false); // Duplicates
-      expect(validateCycle([0, 1, 2, 4], 4)).toBe(false); // Out of bounds
-      expect(validateCycle([-1, 0, 1, 2], 4)).toBe(false); // Negative
+      expect(validateCycle([0, 1, 2], 2, 2)).toBe(false); // Wrong length
+      expect(validateCycle([0, 1, 1, 3], 2, 2)).toBe(false); // Duplicates
+      expect(validateCycle([0, 1, 2, 4], 2, 2)).toBe(false); // Out of bounds
+      expect(validateCycle([-1, 0, 1, 2], 2, 2)).toBe(false); // Negative
     });
   });
 });

--- a/src/tests/integration/gameplay.test.js
+++ b/src/tests/integration/gameplay.test.js
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest';
 import { initializeGame, gameTick, setGameStatus } from '../../engine/gameEngine.js';
 import { seed } from '../../engine/rng.js';
 import { GAME_STATUS } from '../../engine/types.js';
+import { indexToPosition } from '../../utils/math.js';
 
 describe('Gameplay Integration', () => {
   it('should run 1000 ticks without errors on small grid', () => {
@@ -40,6 +41,7 @@ describe('Gameplay Integration', () => {
     state = setGameStatus(state, GAME_STATUS.PLAYING);
 
     for (let i = 0; i < 50; i++) {
+      const previousHead = state.snake.body[0];
       const result = gameTick(state);
       if (!result.result.valid) break;
 
@@ -52,6 +54,11 @@ describe('Gameplay Integration', () => {
       expect(state.fruit).toBeLessThan(36);
       expect(state.moves).toBe(i + 1);
 
+      const newHead = state.snake.body[0];
+      const [prevRow, prevCol] = indexToPosition(previousHead, state.config.cols);
+      const [newRow, newCol] = indexToPosition(newHead, state.config.cols);
+      expect(Math.abs(prevRow - newRow) + Math.abs(prevCol - newCol)).toBe(1);
+
       // Snake should not overlap with itself
       const uniqueCells = new Set(state.snake.body);
       expect(uniqueCells.size).toBe(state.snake.body.length);
@@ -61,5 +68,29 @@ describe('Gameplay Integration', () => {
         expect(state.snake.occupied.has(state.fruit)).toBe(false);
       }
     }
+  });
+
+  it('should complete a full game without breaking cycle invariants', () => {
+    seed(2024);
+    const config = { rows: 8, cols: 8, seed: 2024, shortcutsEnabled: true };
+    let state = initializeGame(config);
+    state = setGameStatus(state, GAME_STATUS.PLAYING);
+
+    const maxIterations = state.cycle.length * 20;
+    let iterations = 0;
+
+    while (state.status === GAME_STATUS.PLAYING && iterations < maxIterations) {
+      const result = gameTick(state);
+      expect(result.result.valid).toBe(true);
+      expect(result.state.cycleIndex).toBeInstanceOf(Map);
+      expect(result.state.snake.occupied).toBeInstanceOf(Set);
+
+      state = result.state;
+      iterations += 1;
+    }
+
+    expect(iterations).toBeLessThanOrEqual(maxIterations);
+    expect(state.status).toBe(GAME_STATUS.COMPLETE);
+    expect(state.snake.body.length).toBe(state.cycle.length);
   });
 });

--- a/src/ui/hooks/useCanvas.js
+++ b/src/ui/hooks/useCanvas.js
@@ -1,254 +1,222 @@
-// FILE: src/ui/hooks/useCanvas.js
-/**
- * Simplified Canvas hook - FIXED VERSION
- */
-
-import { useRef, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { indexToPosition } from '../../utils/math.js';
-import { COLORS } from '../../utils/constants.js';
+import { COLORS, DEFAULT_CONFIG } from '../../utils/constants.js';
 
-export function useCanvas(gameState, settings) {
+const noop = () => {};
+const RAF_FALLBACK = typeof window !== 'undefined' && window.requestAnimationFrame
+  ? window.requestAnimationFrame.bind(window)
+  : (cb) => setTimeout(cb, 16);
+const CANCEL_RAF_FALLBACK = typeof window !== 'undefined' && window.cancelAnimationFrame
+  ? window.cancelAnimationFrame.bind(window)
+  : clearTimeout;
+
+function drawGrid(ctx, rows, cols, cellSize) {
+  ctx.strokeStyle = '#1f2933';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+
+  for (let row = 0; row <= rows; row++) {
+    const y = row * cellSize + 0.5;
+    ctx.moveTo(0, y);
+    ctx.lineTo(cols * cellSize, y);
+  }
+
+  for (let col = 0; col <= cols; col++) {
+    const x = col * cellSize + 0.5;
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, rows * cellSize);
+  }
+
+  ctx.stroke();
+}
+
+function drawCells(ctx, cells, cols, cellSize, color, shrink = 0) {
+  if (!Array.isArray(cells)) return;
+  ctx.fillStyle = color;
+  const size = cellSize - shrink;
+  const offset = shrink / 2;
+
+  for (const cell of cells) {
+    if (cell < 0) continue;
+    const [row, col] = indexToPosition(cell, cols);
+    ctx.fillRect(col * cellSize + offset, row * cellSize + offset, size, size);
+  }
+}
+
+function drawCycle(ctx, cycle, cols, cellSize) {
+  if (!Array.isArray(cycle) || cycle.length === 0) return;
+
+  ctx.strokeStyle = COLORS.CYCLE;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+
+  for (let i = 0; i < cycle.length; i++) {
+    const from = cycle[i];
+    const to = cycle[(i + 1) % cycle.length];
+    if (from < 0 || to < 0) continue;
+
+    const [fromRow, fromCol] = indexToPosition(from, cols);
+    const [toRow, toCol] = indexToPosition(to, cols);
+
+    const fromX = fromCol * cellSize + cellSize / 2;
+    const fromY = fromRow * cellSize + cellSize / 2;
+    const toX = toCol * cellSize + cellSize / 2;
+    const toY = toRow * cellSize + cellSize / 2;
+
+    if (i === 0) {
+      ctx.moveTo(fromX, fromY);
+    }
+    ctx.lineTo(toX, toY);
+  }
+
+  ctx.stroke();
+}
+
+function drawShortcut(ctx, shortcut, cols, cellSize) {
+  if (!Array.isArray(shortcut) || shortcut.length < 2) return;
+
+  ctx.strokeStyle = COLORS.SHORTCUT_EDGE;
+  ctx.lineWidth = 3;
+  ctx.lineCap = 'round';
+  ctx.beginPath();
+
+  const [from, to] = shortcut;
+  const [fromRow, fromCol] = indexToPosition(from, cols);
+  const [toRow, toCol] = indexToPosition(to, cols);
+
+  ctx.moveTo(fromCol * cellSize + cellSize / 2, fromRow * cellSize + cellSize / 2);
+  ctx.lineTo(toCol * cellSize + cellSize / 2, toRow * cellSize + cellSize / 2);
+  ctx.stroke();
+}
+
+function drawPlannedPath(ctx, snakeHead, path, cols, cellSize) {
+  if (!Array.isArray(path) || path.length === 0 || snakeHead === undefined) return;
+
+  ctx.strokeStyle = COLORS.SHORTCUT;
+  ctx.lineWidth = 2;
+  ctx.setLineDash([cellSize / 2, cellSize / 2]);
+  ctx.beginPath();
+
+  const [headRow, headCol] = indexToPosition(snakeHead, cols);
+  ctx.moveTo(headCol * cellSize + cellSize / 2, headRow * cellSize + cellSize / 2);
+
+  for (const cell of path) {
+    const [row, col] = indexToPosition(cell, cols);
+    ctx.lineTo(col * cellSize + cellSize / 2, row * cellSize + cellSize / 2);
+  }
+
+  ctx.stroke();
+  ctx.setLineDash([]);
+}
+
+export function useCanvas(gameState, settings = DEFAULT_CONFIG) {
   const canvasRef = useRef(null);
   const ctxRef = useRef(null);
-  const setupAttemptRef = useRef(0);
-  const hasSetupRef = useRef(false);
+  const rafRef = useRef(null);
+  const drawOptionsRef = useRef({ showCycle: true, showShortcuts: true });
 
-  const { rows = 20, cols = 20 } = settings || {};
-  const cellSize = 24;
+  const rows = settings?.rows ?? DEFAULT_CONFIG.rows;
+  const cols = settings?.cols ?? DEFAULT_CONFIG.cols;
+  const cellSize = settings?.cellSize ?? DEFAULT_CONFIG.cellSize;
 
-  // Setup canvas when ref becomes available or settings change
   useEffect(() => {
-    // Reset setup state when settings change
-    hasSetupRef.current = false;
-    setupAttemptRef.current = 0;
-    
-    const setupCanvas = () => {
-      if (hasSetupRef.current) return; // Already set up
-      
-      const canvas = canvasRef.current;
-      if (!canvas) {
-        setupAttemptRef.current += 1;
-        if (setupAttemptRef.current < 50) { // Try for up to 500ms
-          console.log(`Canvas ref not available yet, retrying... (attempt ${setupAttemptRef.current})`);
-          setTimeout(setupCanvas, 10);
-        } else {
-          console.error('Failed to get canvas ref after 50 attempts');
-        }
-        return;
-      }
+    const canvas = canvasRef.current;
+    if (!canvas) return;
 
-      console.log('Setting up canvas...', { canvas });
-      
-      const ctx = canvas.getContext('2d');
-      if (!ctx) {
-        console.error('Failed to get canvas context');
-        return;
-      }
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
 
-      // Setup canvas dimensions
-      const width = cols * cellSize;
-      const height = rows * cellSize;
-      
-      console.log('Setting canvas dimensions:', { width, height, cols, rows, cellSize });
-      
-      canvas.width = width;
-      canvas.height = height;
-      canvas.style.width = `${width}px`;
-      canvas.style.height = `${height}px`;
-      
-      ctx.imageSmoothingEnabled = false;
-      ctxRef.current = ctx;
-      hasSetupRef.current = true;
+    const width = cols * cellSize;
+    const height = rows * cellSize;
+    canvas.width = width;
+    canvas.height = height;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    ctx.imageSmoothingEnabled = false;
+    ctxRef.current = ctx;
 
-      console.log('Canvas setup complete:', { width, height, contextSet: !!ctxRef.current });
+    ctx.fillStyle = COLORS.BACKGROUND;
+    ctx.fillRect(0, 0, width, height);
 
-      // Draw a simple test pattern to verify canvas works
-      ctx.fillStyle = '#0f172a'; // Use hardcoded background color first
-      ctx.fillRect(0, 0, width, height);
-      ctx.fillStyle = '#ffffff';
-      ctx.fillRect(10, 10, 30, 30);
-      ctx.fillStyle = '#ff0000';
-      ctx.fillRect(50, 10, 30, 30);
-      console.log('Drew test pattern with context:', !!ctx);
+    return () => {
+      ctxRef.current = null;
     };
+  }, [rows, cols, cellSize]);
 
-    // Start setup immediately
-    setupCanvas();
-  }, [cols, rows, cellSize]);
+  const render = useCallback(
+    (options = {}) => {
+      const ctx = ctxRef.current;
+      if (!ctx) return;
 
-  // Drawing functions
-  const drawCell = useCallback((cellIndex, color, size = cellSize - 2) => {
-    const ctx = ctxRef.current;
-    if (!ctx || cellIndex < 0) return;
+      const appliedOptions = {
+        ...drawOptionsRef.current,
+        ...options,
+      };
+      drawOptionsRef.current = appliedOptions;
 
-    try {
-      const [row, col] = indexToPosition(cellIndex, cols);
-      const x = col * cellSize + (cellSize - size) / 2;
-      const y = row * cellSize + (cellSize - size) / 2;
-
-      ctx.fillStyle = color;
-      ctx.fillRect(x, y, size, size);
-    } catch (error) {
-      console.warn('Error in drawCell:', error);
-    }
-  }, [cols, cellSize]);
-
-  const drawCircle = useCallback((cellIndex, color, radius = cellSize / 3) => {
-    const ctx = ctxRef.current;
-    if (!ctx || cellIndex < 0) return;
-
-    try {
-      const [row, col] = indexToPosition(cellIndex, cols);
-      const x = col * cellSize + cellSize / 2;
-      const y = row * cellSize + cellSize / 2;
-
-      ctx.fillStyle = color;
-      ctx.beginPath();
-      ctx.arc(x, y, radius, 0, Math.PI * 2);
-      ctx.fill();
-    } catch (error) {
-      console.warn('Error in drawCircle:', error);
-    }
-  }, [cols, cellSize]);
-
-  const drawLine = useCallback((fromIndex, toIndex, color, width = 1) => {
-    const ctx = ctxRef.current;
-    if (!ctx || fromIndex < 0 || toIndex < 0) return;
-
-    try {
-      const [fromRow, fromCol] = indexToPosition(fromIndex, cols);
-      const [toRow, toCol] = indexToPosition(toIndex, cols);
-
-      const x1 = fromCol * cellSize + cellSize / 2;
-      const y1 = fromRow * cellSize + cellSize / 2;
-      const x2 = toCol * cellSize + cellSize / 2;
-      const y2 = toRow * cellSize + cellSize / 2;
-
-      ctx.strokeStyle = color;
-      ctx.lineWidth = width;
-      ctx.beginPath();
-      ctx.moveTo(x1, y1);
-      ctx.lineTo(x2, y2);
-      ctx.stroke();
-    } catch (error) {
-      console.warn('Error in drawLine:', error);
-    }
-  }, [cols, cellSize]);
-
-  // Main draw function
-  const draw = useCallback((options = {}) => {
-    const ctx = ctxRef.current;
-    if (!ctx) {
-      console.warn('No canvas context available in draw function');
-      return;
-    }
-
-    const { showCycle = true, showShortcuts = true } = options;
-
-    console.log('Drawing with gameState:', {
-      hasGameState: !!gameState,
-      snakeLength: gameState?.snake?.body?.length,
-      fruit: gameState?.fruit,
-      status: gameState?.status
-    });
-
-    try {
-      // Clear canvas and draw background
       const width = cols * cellSize;
       const height = rows * cellSize;
+
       ctx.clearRect(0, 0, width, height);
-      ctx.fillStyle = '#0f172a'; // Use hardcoded background color
+      ctx.fillStyle = COLORS.BACKGROUND;
       ctx.fillRect(0, 0, width, height);
 
-      if (!gameState) {
-        console.log('No gameState to draw - drawing test pattern instead');
-        // Draw test pattern when no game state
-        ctx.fillStyle = '#ffffff';
-        ctx.fillRect(50, 50, 50, 50);
-        return;
+      drawGrid(ctx, rows, cols, cellSize);
+
+      if (!gameState) return;
+
+      const { cycle, snake, fruit, plannerData } = gameState;
+      const snakeBody = snake?.body ?? [];
+      const snakeHead = snakeBody[0];
+
+      if (appliedOptions.showCycle) {
+        drawCycle(ctx, cycle, cols, cellSize);
       }
 
-      const { snake, fruit, cycle, plannerData } = gameState;
-
-      // Draw grid
-      ctx.strokeStyle = '#374151';
-      ctx.lineWidth = 1;
-      ctx.beginPath();
-
-      for (let i = 0; i <= rows; i++) {
-        const y = i * cellSize + 0.5;
-        ctx.moveTo(0, y);
-        ctx.lineTo(width, y);
-      }
-
-      for (let i = 0; i <= cols; i++) {
-        const x = i * cellSize + 0.5;
-        ctx.moveTo(x, 0);
-        ctx.lineTo(x, height);
-      }
-
-      ctx.stroke();
-
-      // Draw Hamiltonian cycle
-      if (showCycle && cycle && cycle.length > 0) {
-        console.log('Drawing Hamiltonian cycle with length:', cycle.length);
-        for (let i = 0; i < cycle.length; i++) {
-          const fromIndex = cycle[i];
-          const toIndex = cycle[(i + 1) % cycle.length];
-          drawLine(fromIndex, toIndex, '#1e40af30', 1); // Use hardcoded blue color
-        }
-      }
-
-      // Draw fruit
       if (fruit !== undefined && fruit >= 0) {
-        console.log('Drawing fruit at position:', fruit);
-        drawCircle(fruit, '#ef4444'); // Use hardcoded red color
+        const [fruitRow, fruitCol] = indexToPosition(fruit, cols);
+        ctx.fillStyle = COLORS.FRUIT;
+        ctx.beginPath();
+        ctx.arc(
+          fruitCol * cellSize + cellSize / 2,
+          fruitRow * cellSize + cellSize / 2,
+          Math.max(cellSize * 0.3, 4),
+          0,
+          Math.PI * 2
+        );
+        ctx.fill();
       }
 
-      // Draw snake
-      if (snake?.body && snake.body.length > 0) {
-        console.log('Drawing snake with length:', snake.body.length);
-        snake.body.forEach((cellIndex, i) => {
-          const isHead = i === 0;
-          const color = isHead ? '#10b981' : '#059669'; // Use hardcoded green colors
-          const size = isHead ? cellSize - 2 : cellSize - 4;
-          drawCell(cellIndex, color, size);
-        });
+      if (appliedOptions.showShortcuts && plannerData?.plannedPath?.length) {
+        drawPlannedPath(ctx, snakeHead, plannerData.plannedPath, cols, cellSize);
       }
 
-      // Draw shortcut edge
-      if (showShortcuts && plannerData?.shortcutEdge) {
-        const [from, to] = plannerData.shortcutEdge;
-        drawLine(from, to, '#fbbf24', 3); // Use hardcoded yellow color
+      if (appliedOptions.showShortcuts && plannerData?.shortcutEdge) {
+        drawShortcut(ctx, plannerData.shortcutEdge, cols, cellSize);
       }
 
-      console.log('Draw complete - Snake length:', snake?.body?.length, 'Fruit:', fruit);
+      if (snakeBody.length) {
+        drawCells(ctx, snakeBody.slice(1), cols, cellSize, COLORS.SNAKE_BODY, 4);
+        drawCells(ctx, [snakeHead], cols, cellSize, COLORS.SNAKE_HEAD, 2);
+      }
+    },
+    [cols, rows, cellSize, gameState]
+  );
 
-    } catch (error) {
-      console.error('Error in draw:', error);
-    }
-  }, [gameState, cols, rows, cellSize, drawCell, drawCircle, drawLine]);
-
-  // Redraw when gameState changes - prevent infinite loops
   useEffect(() => {
-    console.log('Draw effect triggered:', { 
-      hasContext: !!ctxRef.current, 
-      hasGameState: !!gameState,
-      gameStateStatus: gameState?.status,
-      moves: gameState?.moves,
-      snakeLength: gameState?.snake?.body?.length
-    });
-    
-    if (ctxRef.current && gameState) {
-      // Use requestAnimationFrame to prevent excessive redraws
-      requestAnimationFrame(() => draw());
-    }
-  }, [gameState?.moves, gameState?.status, gameState?.snake?.body?.length, gameState?.fruit, draw]);
+    if (!ctxRef.current) return noop;
 
-  // Remove the redundant effect that was causing infinite loops
+    rafRef.current = RAF_FALLBACK(() => render());
+    return () => {
+      if (rafRef.current !== null) {
+        CANCEL_RAF_FALLBACK(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [render]);
 
   return {
     canvasRef,
-    draw,
+    draw: render,
   };
 }

--- a/src/ui/hooks/useGameState.js
+++ b/src/ui/hooks/useGameState.js
@@ -1,194 +1,191 @@
-// FILE: src/ui/hooks/useGameState.js
-/**
- * React hook for managing game state - SIMPLIFIED FIXED VERSION
- */
-
-import { useState, useCallback, useRef, useEffect } from 'react';
-import { initializeGame, resetGame } from '../../engine/gameEngine.js';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { initializeGame } from '../../engine/gameEngine.js';
 import { GameLoop } from '../../game/gameLoop.js';
 import { loadSettings, saveSettings, updateHighScore } from '../../game/settings.js';
 import { seed } from '../../engine/rng.js';
+import { GAME_STATUS } from '../../engine/types.js';
+import { DEFAULT_CONFIG } from '../../utils/constants.js';
+import { cyclicDistance } from '../../utils/math.js';
 
-export function useGameState() {
-  const [settings, setSettings] = useState(() => loadSettings());
-  const [gameState, setGameState] = useState(null);
-  const [stats, setStats] = useState({});
+function safeLoadSettings() {
+  try {
+    return loadSettings();
+  } catch (error) {
+    return { ...DEFAULT_CONFIG };
+  }
+}
 
-  const gameLoopRef = useRef(null);
-  const initializedRef = useRef(false);
-
-  // Helper functions for stats calculation
-  const calculateDistance = useCallback((state) => {
-    if (!state.snake?.body?.[0] || !state.cycleIndex || state.fruit === undefined) return 0;
-    const headPos = state.cycleIndex.get(state.snake.body[0]);
-    const fruitPos = state.cycleIndex.get(state.fruit);
-    if (headPos === undefined || fruitPos === undefined) return 0;
-    return (fruitPos - headPos + state.cycle.length) % state.cycle.length;
-  }, []);
-
-  const calculateTailDistance = useCallback((state) => {
-    if (!state.snake?.body || state.snake.body.length < 2 || !state.cycleIndex) return 0;
-    const headPos = state.cycleIndex.get(state.snake.body[0]);
-    const tailPos = state.cycleIndex.get(state.snake.body[state.snake.body.length - 1]);
-    if (headPos === undefined || tailPos === undefined) return 0;
-    return (tailPos - headPos + state.cycle.length) % state.cycle.length;
-  }, []);
-
-  // Initialize game state ONCE when component mounts or settings change meaningfully
-  useEffect(() => {
-    if (initializedRef.current) {
-      return; // Already initialized
-    }
-    
-    console.log('Initializing game state...');
-    seed(settings.seed);
-    const newState = initializeGame(settings);
-    setGameState(newState);
-    
-    // Reset stats
-    const initialStats = {
+function computeStats(state) {
+  if (!state) {
+    return {
       moves: 0,
-      length: 1,
+      length: 0,
       score: 0,
-      free: (newState.cycle?.length || 400) - 1,
-      distHeadApple: calculateDistance(newState),
-      distHeadTail: calculateTailDistance(newState),
+      free: 0,
+      distHeadApple: 0,
+      distHeadTail: 0,
       shortcut: false,
       efficiency: 0,
     };
-    setStats(initialStats);
-    
-    initializedRef.current = true;
-  }, [settings.rows, settings.cols, settings.seed, calculateDistance, calculateTailDistance]); // Only reinit on major setting changes
+  }
 
-  // Initialize game loop when gameState becomes available
-  useEffect(() => {
-    if (!gameState) return;
+  const { cycle, cycleIndex, snake, fruit, moves = 0, score = 0, lastMoveWasShortcut } = state;
+  const cycleLength = cycle?.length ?? 0;
+  const body = snake?.body ?? [];
+  const head = body[0];
+  const tail = body[body.length - 1];
 
-    console.log('Setting up game loop...');
-    
-    // Stop existing loop
-    if (gameLoopRef.current) {
-      gameLoopRef.current.stop();
-      gameLoopRef.current = null;
-    }
+  let distHeadApple = 0;
+  let distHeadTail = 0;
 
-    const loop = new GameLoop(
-      gameState,
-      newState => {
-        setGameState(newState);
-        
-        // Update stats
-        const currentStats = {
-          moves: newState.moves || 0,
-          length: newState.snake?.body?.length || 1,
-          score: newState.score || 0,
-          free: (newState.cycle?.length || 400) - (newState.snake?.body?.length || 1),
-          distHeadApple: calculateDistance(newState),
-          distHeadTail: calculateTailDistance(newState),
-          shortcut: newState.lastMoveWasShortcut || false,
-          efficiency: newState.moves > 0 ? Math.round((newState.score / newState.moves) * 100) : 0,
-        };
-        setStats(currentStats);
+  if (cycle && cycleIndex instanceof Map && head !== undefined) {
+    const headPos = cycleIndex.get(head);
 
-        // Update high score if game ended
-        if (newState.status === 'gameOver' || newState.status === 'complete') {
-          updateHighScore(newState.score);
+    if (headPos !== undefined) {
+      if (fruit !== undefined && fruit >= 0) {
+        const fruitPos = cycleIndex.get(fruit);
+        if (fruitPos !== undefined) {
+          distHeadApple = cyclicDistance(headPos, fruitPos, cycleLength);
         }
-      },
-      settings
-    );
+      }
 
+      if (tail !== undefined) {
+        const tailPos = cycleIndex.get(tail);
+        if (tailPos !== undefined) {
+          distHeadTail = cyclicDistance(headPos, tailPos, cycleLength);
+        }
+      }
+    }
+  }
+
+  return {
+    moves,
+    length: body.length,
+    score,
+    free: Math.max(cycleLength - body.length, 0),
+    distHeadApple,
+    distHeadTail,
+    shortcut: Boolean(lastMoveWasShortcut),
+    efficiency: moves > 0 ? Math.round((score / moves) * 100) : 0,
+  };
+}
+
+export function useGameState() {
+  const initialSettingsRef = useRef(safeLoadSettings());
+  const settingsRef = useRef(initialSettingsRef.current);
+  const gameLoopRef = useRef(null);
+  const initialStateRef = useRef(null);
+
+  const [settings, setSettings] = useState(initialSettingsRef.current);
+  const [gameState, setGameState] = useState(() => {
+    seed(initialSettingsRef.current.seed ?? DEFAULT_CONFIG.seed);
+    const initialState = initializeGame(initialSettingsRef.current);
+    initialStateRef.current = initialState;
+    return initialState;
+  });
+  const [stats, setStats] = useState(() => computeStats(initialStateRef.current));
+
+  useEffect(() => {
+    settingsRef.current = settings;
+  }, [settings]);
+
+  const handleStateUpdate = useCallback(nextState => {
+    setGameState(nextState);
+    setStats(computeStats(nextState));
+
+    if (
+      nextState.status === GAME_STATUS.GAME_OVER ||
+      nextState.status === GAME_STATUS.COMPLETE
+    ) {
+      updateHighScore(nextState.score ?? 0);
+    }
+  }, []);
+
+  useEffect(() => {
+    const loop = new GameLoop(initialStateRef.current, handleStateUpdate, settingsRef.current);
     gameLoopRef.current = loop;
 
     return () => {
-      if (gameLoopRef.current) {
-        gameLoopRef.current.stop();
-        gameLoopRef.current = null;
-      }
+      loop.stop();
+      gameLoopRef.current = null;
     };
-  }, [gameState?.snake?.body?.length, calculateDistance, calculateTailDistance, settings]);
+  }, [handleStateUpdate]);
 
-  // Update game loop speed when tick interval changes
-  useEffect(() => {
-    if (gameLoopRef.current && settings.tickMs !== undefined) {
-      gameLoopRef.current.setTickInterval(settings.tickMs);
-    }
-  }, [settings.tickMs]);
+  const applyNewState = useCallback(newState => {
+    setGameState(newState);
+    setStats(computeStats(newState));
 
-  // Update settings
-  const updateSettings = useCallback(newSettings => {
-    setSettings(prevSettings => {
-      const updatedSettings = { ...prevSettings, ...newSettings };
-      saveSettings(updatedSettings);
-      
-      // Check if we need to reinitialize the game
-      const needsReinit = (
-        updatedSettings.rows !== prevSettings.rows ||
-        updatedSettings.cols !== prevSettings.cols ||
-        updatedSettings.seed !== prevSettings.seed
-      );
-      
-      if (needsReinit) {
-        initializedRef.current = false;
+    if (gameLoopRef.current) {
+      gameLoopRef.current.reset(newState);
+      if (typeof newState.config?.tickMs === 'number') {
+        gameLoopRef.current.setTickInterval(newState.config.tickMs);
       }
-      
-      return updatedSettings;
-    });
-  }, []);
-
-  // Game control functions
-  const startGame = useCallback(() => {
-    if (gameLoopRef.current) {
-      gameLoopRef.current.start();
-    }
-  }, []);
-
-  const pauseGame = useCallback(() => {
-    if (gameLoopRef.current) {
-      gameLoopRef.current.pause();
-    }
-  }, []);
-
-  const stepGame = useCallback(() => {
-    if (gameLoopRef.current) {
-      gameLoopRef.current.step();
     }
   }, []);
 
   const resetGameState = useCallback(() => {
-    console.log('Resetting game state...');
-    seed(settings.seed);
-    const newState = resetGame(settings);
-    setGameState(newState);
-    
-    // Reset stats
-    const resetStats = {
-      moves: 0,
-      length: 1,
-      score: 0,
-      free: (newState.cycle?.length || 400) - 1,
-      distHeadApple: calculateDistance(newState),
-      distHeadTail: calculateTailDistance(newState),
-      shortcut: false,
-      efficiency: 0,
-    };
-    setStats(resetStats);
-  }, [settings, calculateDistance, calculateTailDistance]);
+    const currentSettings = settingsRef.current;
+    seed(currentSettings.seed ?? DEFAULT_CONFIG.seed);
+    const freshState = initializeGame(currentSettings);
+    applyNewState(freshState);
+  }, [applyNewState]);
+
+  const updateSettings = useCallback(updates => {
+    setSettings(prevSettings => {
+      const merged = { ...prevSettings, ...updates };
+      saveSettings(merged);
+
+      const requiresReinit =
+        merged.rows !== prevSettings.rows ||
+        merged.cols !== prevSettings.cols ||
+        merged.seed !== prevSettings.seed;
+
+      if (requiresReinit) {
+        seed(merged.seed ?? DEFAULT_CONFIG.seed);
+        const freshState = initializeGame(merged);
+        applyNewState(freshState);
+      } else {
+        setGameState(prevState => {
+          if (!prevState) return prevState;
+          return {
+            ...prevState,
+            config: { ...prevState.config, ...updates },
+          };
+        });
+
+        if (gameLoopRef.current && typeof updates.tickMs === 'number') {
+          gameLoopRef.current.setTickInterval(merged.tickMs);
+        }
+      }
+
+      return merged;
+    });
+  }, [applyNewState]);
+
+  const startGame = useCallback(() => {
+    gameLoopRef.current?.start();
+  }, []);
+
+  const pauseGame = useCallback(() => {
+    gameLoopRef.current?.pause();
+  }, []);
+
+  const stepGame = useCallback(() => {
+    gameLoopRef.current?.step();
+  }, []);
 
   const toggleGame = useCallback(() => {
     if (!gameState) return;
-    
-    if (gameState.status === 'playing') {
+
+    if (gameState.status === GAME_STATUS.PLAYING) {
       pauseGame();
-    } else if (gameState.status === 'paused') {
+    } else if (gameState.status === GAME_STATUS.PAUSED) {
       startGame();
     } else {
       resetGameState();
     }
-  }, [gameState?.status, startGame, pauseGame, resetGameState]);
+  }, [gameState, pauseGame, startGame, resetGameState]);
 
-  // Return current state
   return {
     gameState,
     stats,

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,12 +7,12 @@ export const DEFAULT_CONFIG = {
   rows: 20,
   cols: 20,
   tickMs: 100,
-  seed: 42, // Use a fixed seed instead of Date.now() for consistency
-  shortcutsEnabled: false, // Temporarily disable shortcuts to debug teleporting
+  seed: 42,
+  shortcutsEnabled: true,
   safetyBuffer: 2,
   lateGameLock: 4,
   minShortcutWindow: 2,
-  scorePerfruit: 10,
+  scorePerFruit: 10,
   shortcutBonus: 5,
   cellSize: 24,
 };


### PR DESCRIPTION
## Summary
- rebuild the Hamiltonian cycle generator to cover both even-row and even-column grids with adjacency validation
- refresh canvas, game loop, and React hooks to render the grid, snake, cycle, and shortcuts while keeping deterministic state updates
- enable shortcuts by default, tighten scoring logic, and expand integration/unit tests for Hamiltonian coverage and full-game completion

## Testing
- npm test -- --run
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cc37de3e948330853fa7e5233014f5