### PR TITLE
Add headless simulation runner and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,29 @@ npm test
 
 # Build for production
 npm run build
+
+# Run headless simulations
+npm run simulate -- --games 1000 --rows 20 --cols 20 --details
 ```
+
+## 🧪 Headless simulations
+
+Use the built-in simulator to execute thousands of AI-only games without the browser. This is ideal for collecting statistics such as completion rate, average moves, or duration for a given grid size.
+
+```bash
+# Run 1,000 games on a 20x20 board and show summary plus sample runs
+npm run simulate -- --games 1000 --rows 20 --cols 20 --details --sample 5
+
+# Output the raw JSON data for further processing
+npm run simulate -- --games 500 --rows 16 --cols 16 --json
+```
+
+Key flags:
+
+- `--games` – number of games to run (defaults to 1)
+- `--rows` / `--cols` – grid dimensions
+- `--seed` – base seed for deterministic runs
+- `--uniqueSeeds=false` – reuse the same seed for each run
+- `--details` – print a table with per-game results
+- `--json` – emit machine-readable JSON instead of formatted text
+- `--shortcutsEnabled=false` – disable shortcut logic for comparison runs

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "type-check": "jsdoc -t templates/haruki -d docs src/**/*.js",
+    "simulate": "node scripts/simulate.js",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/scripts/simulate.js
+++ b/scripts/simulate.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/* eslint-env node */
+/* global process */
+// FILE: scripts/simulate.js
+import { simulateGames } from '../src/simulation/simulator.js';
+import { DEFAULT_CONFIG } from '../src/utils/constants.js';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) continue;
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      args[key] = next;
+      i += 1;
+    } else {
+      args[key] = true;
+    }
+  }
+  return args;
+}
+
+function toInteger(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+function toNumber(value, fallback) {
+  const parsed = Number.parseFloat(value);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+function toBoolean(value, fallback) {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const lowered = value.toLowerCase();
+    if (['true', '1', 'yes', 'y'].includes(lowered)) return true;
+    if (['false', '0', 'no', 'n'].includes(lowered)) return false;
+  }
+  return Boolean(value);
+}
+
+function formatMs(value) {
+  return `${value.toFixed(2)} ms`;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const args = parseArgs(argv);
+
+  const gameCount = toInteger(args.games ?? args.count, 1);
+  const rows = toInteger(args.rows, DEFAULT_CONFIG.rows);
+  const cols = toInteger(args.cols, DEFAULT_CONFIG.cols);
+  const tickMs = args.tickMs !== undefined ? toNumber(args.tickMs, DEFAULT_CONFIG.tickMs) : undefined;
+  const shortcutsEnabled =
+    args.shortcutsEnabled !== undefined
+      ? toBoolean(args.shortcutsEnabled, DEFAULT_CONFIG.shortcutsEnabled)
+      : undefined;
+  const uniqueSeeds = toBoolean(args.uniqueSeeds, true);
+  const includeRuns = toBoolean(args.details ?? args.includeRuns, false);
+  const outputJson = toBoolean(args.json, false);
+
+  const config = {
+    rows,
+    cols,
+  };
+
+  if (tickMs !== undefined) {
+    config.tickMs = tickMs;
+  }
+  if (shortcutsEnabled !== undefined) {
+    config.shortcutsEnabled = shortcutsEnabled;
+  }
+  if (args.seed !== undefined) {
+    config.seed = toInteger(args.seed, DEFAULT_CONFIG.seed);
+  }
+  if (args.safetyBuffer !== undefined) {
+    config.safetyBuffer = toInteger(args.safetyBuffer, DEFAULT_CONFIG.safetyBuffer);
+  }
+  if (args.lateGameLock !== undefined) {
+    config.lateGameLock = toInteger(args.lateGameLock, DEFAULT_CONFIG.lateGameLock);
+  }
+  if (args.minShortcutWindow !== undefined) {
+    config.minShortcutWindow = toInteger(args.minShortcutWindow, DEFAULT_CONFIG.minShortcutWindow);
+  }
+
+  const { summary, runs } = simulateGames({
+    games: gameCount,
+    config,
+    uniqueSeeds,
+    includeRuns: includeRuns || outputJson,
+  });
+
+  if (outputJson) {
+    const payload = {
+      summary,
+      runs: includeRuns || outputJson ? runs : undefined,
+    };
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  console.log('🐍 Snake AI batch simulation');
+  console.log(`- Games: ${summary.gameCount}`);
+  console.log(`- Grid: ${summary.grid.rows} x ${summary.grid.cols}`);
+  console.log(`- Completion rate: ${(summary.statuses.completionRate * 100).toFixed(2)}%`);
+  console.log(`- Average moves: ${summary.averages.moves.toFixed(2)}`);
+  console.log(`- Average score: ${summary.averages.score.toFixed(2)}`);
+  console.log(`- Average duration: ${formatMs(summary.averages.durationMs)}`);
+
+  if (summary.statuses.complete > 0) {
+    console.log(`- Fastest completion: ${formatMs(summary.durations.fastestCompletionMs)}`);
+    console.log(`- Slowest completion: ${formatMs(summary.durations.slowestCompletionMs)}`);
+  }
+
+  if (includeRuns && runs) {
+    const displayCount = Math.min(runs.length, toInteger(args.sample ?? 10, 10));
+    console.log(`\nSample of ${displayCount} runs:`);
+    const table = runs.slice(0, displayCount).map((run, index) => ({
+      game: index + 1,
+      seed: run.seed,
+      status: run.status,
+      moves: run.moves,
+      score: run.score,
+      duration: `${run.durationMs.toFixed(2)} ms`,
+    }));
+    console.table(table);
+  }
+}
+
+main();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,16 +5,19 @@ import { useGameState } from './ui/hooks/useGameState.js';
 import { useCanvas } from './ui/hooks/useCanvas.js';
 
 // UI Components
-const StatCard = ({ label, value, icon: Icon, color = 'blue', subtitle }) => (
-  <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-4 hover:bg-white/10 transition-all duration-300">
-    <div className="flex items-center justify-between mb-2">
-      <Icon className={`w-5 h-5 text-${color}-400`} />
-      <span className={`text-2xl font-bold text-${color}-400`}>{value}</span>
+const StatCard = ({ label, value, icon, color = 'blue', subtitle }) => {
+  const IconComponent = icon;
+  return (
+    <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-4 hover:bg-white/10 transition-all duration-300">
+      <div className="flex items-center justify-between mb-2">
+        <IconComponent className={`w-5 h-5 text-${color}-400`} />
+        <span className={`text-2xl font-bold text-${color}-400`}>{value}</span>
+      </div>
+      <p className="text-sm text-gray-300 font-medium">{label}</p>
+      {subtitle && <p className="text-xs text-gray-400 mt-1">{subtitle}</p>}
     </div>
-    <p className="text-sm text-gray-300 font-medium">{label}</p>
-    {subtitle && <p className="text-xs text-gray-400 mt-1">{subtitle}</p>}
-  </div>
-);
+  );
+};
 
 StatCard.propTypes = {
   label: PropTypes.string.isRequired,

--- a/src/simulation/index.js
+++ b/src/simulation/index.js
@@ -1,0 +1,2 @@
+// FILE: src/simulation/index.js
+export { runGame, simulateGames } from './simulator.js';

--- a/src/simulation/simulator.js
+++ b/src/simulation/simulator.js
@@ -1,0 +1,210 @@
+// FILE: src/simulation/simulator.js
+/**
+ * Simulation utilities for running many AI Snake games without the UI layer.
+ */
+
+import { initializeGame, setGameStatus, gameTick, getGameStats } from '../engine/gameEngine.js';
+import { GAME_STATUS } from '../engine/types.js';
+import { DEFAULT_CONFIG } from '../utils/constants.js';
+import { seed as setSeed } from '../engine/rng.js';
+
+const getTimestamp = () =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+
+function normalizeConfig(config = {}) {
+  return { ...DEFAULT_CONFIG, ...config };
+}
+
+function prepareConfig(baseConfig, index, uniqueSeeds) {
+  if (!uniqueSeeds) {
+    return { ...baseConfig };
+  }
+
+  const baseSeed = baseConfig.seed ?? DEFAULT_CONFIG.seed;
+  return { ...baseConfig, seed: baseSeed + index };
+}
+
+function normalizeBoolean(value, defaultValue) {
+  if (value === undefined || value === null) {
+    return defaultValue;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const lowered = value.toLowerCase();
+    if (lowered === 'true' || lowered === '1' || lowered === 'yes') {
+      return true;
+    }
+    if (lowered === 'false' || lowered === '0' || lowered === 'no') {
+      return false;
+    }
+  }
+  return defaultValue;
+}
+
+/**
+ * Run a single game simulation until it reaches a terminal state.
+ * @param {Object} configOverrides - Optional game configuration overrides.
+ * @param {Object} options - Simulation options.
+ * @param {number} [options.maxTicks=Infinity] - Maximum number of ticks to run.
+ * @returns {Object} Result of the game simulation.
+ */
+export function runGame(configOverrides = {}, options = {}) {
+  const { maxTicks = Infinity } = options;
+  const config = normalizeConfig(configOverrides);
+  const rngSeed = config.seed ?? DEFAULT_CONFIG.seed;
+
+  setSeed(rngSeed);
+
+  let state = initializeGame(config);
+  state = setGameStatus(state, GAME_STATUS.PLAYING);
+
+  const start = getTimestamp();
+  let tickCount = 0;
+
+  while (state.status === GAME_STATUS.PLAYING && tickCount < maxTicks) {
+    const result = gameTick(state);
+    state = result.state;
+    tickCount += 1;
+
+    if (state.status === GAME_STATUS.GAME_OVER || state.status === GAME_STATUS.COMPLETE) {
+      break;
+    }
+  }
+
+  const durationMs = getTimestamp() - start;
+  const stats = getGameStats(state);
+
+  return {
+    seed: rngSeed,
+    config,
+    status: state.status,
+    durationMs,
+    ticks: tickCount,
+    moves: stats.moves,
+    score: stats.score,
+    stats,
+  };
+}
+
+/**
+ * Run multiple games (optionally with unique seeds) and aggregate statistics.
+ * @param {Object} params - Simulation parameters.
+ * @param {number} [params.games=1] - Number of games to run.
+ * @param {Object} [params.config] - Game configuration overrides applied to every run.
+ * @param {boolean|string} [params.uniqueSeeds=true] - Whether to offset the seed for each run.
+ * @param {boolean} [params.includeRuns=false] - Include per-game results in the response.
+ * @param {Object} [params.runOptions] - Options passed to each runGame call.
+ * @param {Function} [params.onProgress] - Progress callback invoked after each game.
+ * @returns {{summary: Object, runs: Object[] | undefined}} Aggregated stats and optional run data.
+ */
+export function simulateGames(params = {}) {
+  const {
+    games = 1,
+    config: configOverrides = {},
+    uniqueSeeds = true,
+    includeRuns = false,
+    runOptions = {},
+    onProgress,
+  } = params;
+
+  const totalGames = Math.max(0, Math.floor(games));
+  const baseConfig = normalizeConfig(configOverrides);
+  const useUniqueSeeds = normalizeBoolean(uniqueSeeds, true);
+
+  const results = [];
+
+  const totals = {
+    moves: 0,
+    score: 0,
+    length: 0,
+    efficiency: 0,
+    free: 0,
+    durationMs: 0,
+  };
+
+  const statuses = {
+    complete: 0,
+    gameOver: 0,
+    other: 0,
+  };
+
+  let minDuration = Number.POSITIVE_INFINITY;
+  let maxDuration = 0;
+  let fastestCompletion = Number.POSITIVE_INFINITY;
+  let slowestCompletion = 0;
+
+  for (let i = 0; i < totalGames; i += 1) {
+    const configForGame = prepareConfig(baseConfig, i, useUniqueSeeds);
+    const result = runGame(configForGame, runOptions);
+
+    totals.moves += result.stats.moves;
+    totals.score += result.stats.score;
+    totals.length += result.stats.length;
+    totals.efficiency += result.stats.efficiency;
+    totals.free += result.stats.free;
+    totals.durationMs += result.durationMs;
+
+    minDuration = Math.min(minDuration, result.durationMs);
+    maxDuration = Math.max(maxDuration, result.durationMs);
+
+    if (result.status === GAME_STATUS.COMPLETE) {
+      statuses.complete += 1;
+      fastestCompletion = Math.min(fastestCompletion, result.durationMs);
+      slowestCompletion = Math.max(slowestCompletion, result.durationMs);
+    } else if (result.status === GAME_STATUS.GAME_OVER) {
+      statuses.gameOver += 1;
+    } else {
+      statuses.other += 1;
+    }
+
+    if (includeRuns) {
+      results.push({ ...result });
+    }
+
+    if (typeof onProgress === 'function') {
+      onProgress({ completed: i + 1, total: totalGames, lastResult: result });
+    }
+  }
+
+  const divisor = totalGames || 1;
+
+  const summary = {
+    gameCount: totalGames,
+    config: baseConfig,
+    grid: { rows: baseConfig.rows, cols: baseConfig.cols },
+    statuses: {
+      complete: statuses.complete,
+      gameOver: statuses.gameOver,
+      other: statuses.other,
+      completionRate: totalGames > 0 ? statuses.complete / totalGames : 0,
+    },
+    averages: {
+      moves: totals.moves / divisor,
+      score: totals.score / divisor,
+      length: totals.length / divisor,
+      free: totals.free / divisor,
+      efficiency: totals.efficiency / divisor,
+      durationMs: totals.durationMs / divisor,
+    },
+    totals: {
+      moves: totals.moves,
+      score: totals.score,
+      durationMs: totals.durationMs,
+    },
+    durations: {
+      minMs: Number.isFinite(minDuration) ? minDuration : null,
+      maxMs: totalGames > 0 ? maxDuration : null,
+      fastestCompletionMs: statuses.complete > 0 ? fastestCompletion : null,
+      slowestCompletionMs: statuses.complete > 0 ? slowestCompletion : null,
+    },
+  };
+
+  return {
+    summary,
+    runs: includeRuns ? results : undefined,
+  };
+}

--- a/src/tests/simulation/simulator.test.js
+++ b/src/tests/simulation/simulator.test.js
@@ -1,0 +1,50 @@
+// FILE: src/tests/simulation/simulator.test.js
+import { describe, expect, it } from 'vitest';
+import { runGame, simulateGames } from '../../simulation/simulator.js';
+import { GAME_STATUS } from '../../engine/types.js';
+
+const TERMINAL_STATUSES = new Set([
+  GAME_STATUS.COMPLETE,
+  GAME_STATUS.GAME_OVER,
+  GAME_STATUS.PAUSED,
+  GAME_STATUS.PLAYING,
+]);
+
+describe('simulation utilities', () => {
+  it('runs a single game to completion or failure', () => {
+    const result = runGame({ rows: 8, cols: 8, seed: 2025 });
+
+    expect(result).toMatchObject({
+      seed: expect.any(Number),
+      status: expect.any(String),
+      durationMs: expect.any(Number),
+      moves: expect.any(Number),
+      score: expect.any(Number),
+      stats: expect.any(Object),
+    });
+
+    expect(TERMINAL_STATUSES.has(result.status)).toBe(true);
+    expect(result.stats.moves).toBeGreaterThan(0);
+  });
+
+  it('aggregates multiple games with deterministic runs when seeds are reused', () => {
+    const { summary, runs } = simulateGames({
+      games: 4,
+      config: { rows: 6, cols: 6, seed: 99 },
+      uniqueSeeds: false,
+      includeRuns: true,
+    });
+
+    expect(summary.gameCount).toBe(4);
+    expect(summary.grid).toEqual({ rows: 6, cols: 6 });
+    expect(runs).toHaveLength(4);
+
+    const uniqueScores = new Set(runs.map((run) => run.score));
+    expect(uniqueScores.size).toBe(1);
+
+    const { complete, gameOver, other } = summary.statuses;
+    expect(complete + gameOver + other).toBe(4);
+    expect(summary.statuses.completionRate).toBeGreaterThanOrEqual(0);
+    expect(summary.statuses.completionRate).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/ui/components/StatsPanel.jsx
+++ b/src/ui/components/StatsPanel.jsx
@@ -7,21 +7,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Info, Zap, TrendingUp, Target, Activity } from 'lucide-react';
 
-const StatCard = ({ label, value, icon: Icon, color = 'blue', subtitle, trend }) => (
-  <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-4 hover:bg-white/10 transition-all duration-300">
-    <div className="flex items-center justify-between mb-2">
-      <Icon className={`w-5 h-5 text-${color}-400`} />
-      <div className="flex items-center gap-2">
-        <span className={`text-2xl font-bold text-${color}-400`}>{value}</span>
-        {trend && (
-          <TrendingUp className={`w-4 h-4 ${trend > 0 ? 'text-green-400' : 'text-red-400'}`} />
-        )}
+const StatCard = ({ label, value, icon, color = 'blue', subtitle, trend }) => {
+  const IconComponent = icon;
+  return (
+    <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-4 hover:bg-white/10 transition-all duration-300">
+      <div className="flex items-center justify-between mb-2">
+        <IconComponent className={`w-5 h-5 text-${color}-400`} />
+        <div className="flex items-center gap-2">
+          <span className={`text-2xl font-bold text-${color}-400`}>{value}</span>
+          {trend && (
+            <TrendingUp className={`w-4 h-4 ${trend > 0 ? 'text-green-400' : 'text-red-400'}`} />
+          )}
+        </div>
       </div>
+      <p className="text-sm text-gray-300 font-medium">{label}</p>
+      {subtitle && <p className="text-xs text-gray-400 mt-1">{subtitle}</p>}
     </div>
-    <p className="text-sm text-gray-300 font-medium">{label}</p>
-    {subtitle && <p className="text-xs text-gray-400 mt-1">{subtitle}</p>}
-  </div>
-);
+  );
+};
 
 const getStatusColor = status => {
   switch (status) {

--- a/src/ui/hooks/useGameState.js
+++ b/src/ui/hooks/useGameState.js
@@ -10,7 +10,7 @@ import { cyclicDistance } from '../../utils/math.js';
 function safeLoadSettings() {
   try {
     return loadSettings();
-  } catch (error) {
+  } catch {
     return { ...DEFAULT_CONFIG };
   }
 }


### PR DESCRIPTION
## Summary
- add a simulation module that can execute many AI-only Snake games and aggregate statistics
- expose a Node CLI and npm script for running headless batches plus documentation on how to use it
- cover the new utilities with tests and tidy minor lint issues around icon props

## Testing
- npm run lint
- npm test -- --run
- npm run simulate -- --games 5 --rows 6 --cols 6 --details --sample 3

------
https://chatgpt.com/codex/tasks/task_b_68cd1bf65c988330b6ac569e2e021ea2